### PR TITLE
My recent changes

### DIFF
--- a/scripts/api_create.py
+++ b/scripts/api_create.py
@@ -6,13 +6,13 @@ Creates the API
 
 import argparse
 import aws_client_api_gateway
-import service_env
+import service_config
 import string
 import arg_parser
 
 def setup_and_parse_args():
     parser = arg_parser.create_parser(desc="""
-    Setup API Gateway in the specified region. Environment implies both region and its use case
+    Setup API Gateway in the specified prefix and region. Prefix implies use case
 
     Example usage:
     python ./api_create.py --file=<config-file.yaml>        # (region us-east-1, developer environment)

--- a/scripts/arg_parser.py
+++ b/scripts/arg_parser.py
@@ -6,7 +6,7 @@ Creates the standard argument parser for use by the AWS CLI scripts
 
 import argparse
 import sys
-import service_env
+import service_config
 import tempfile
 import logger
 import string
@@ -18,7 +18,6 @@ logger = logger.getLogger()
 def create_parser(desc):
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
                                      description=desc)
-    # Add the standard --env argument
     parser.add_argument('--file',
                         required=True, help='The cluster config file')
     return parser
@@ -63,7 +62,7 @@ def parse_config_from(filename, custom_fn_map=None):
     Return the parsed cluster config file.
     """
     preprocessed_file = preprocess_yaml_file(filename)
-    return service_env.load_env_with_extension(preprocessed_file, custom_fn_map)
+    return service_config.load_config_with_extension(preprocessed_file, custom_fn_map)
 
 
 def parse_config_from_args(parser, custom_fn_map=None):
@@ -72,6 +71,6 @@ def parse_config_from_args(parser, custom_fn_map=None):
     """
     args = parse(parser)
     preprocessed_file = preprocess_yaml_file(args.file)
-    env = service_env.load_env_with_extension(preprocessed_file, custom_fn_map)
+    config = service_config.load_config_with_extension(preprocessed_file, custom_fn_map)
     # Check basic things in the config file
-    return env, args
+    return config, args

--- a/scripts/auto_scale.py
+++ b/scripts/auto_scale.py
@@ -12,7 +12,7 @@ import arg_parser
 
 def setup_and_parse_args():
     parser = arg_parser.create_parser(desc="""
-    Setup Auto scale group. Environment implies both region and its use case
+    Setup Auto scale group.
 
     Example usage:
     python ./auto_scale_create.py --file=<config-file.yaml>        # (region us-east-1, developer environment)

--- a/scripts/aws_client_sqs.py
+++ b/scripts/aws_client_sqs.py
@@ -30,7 +30,7 @@ class SqsClient(aws_client.AwsClient):
 
     def create_sqs(self):
         qname = self.config.create_name_with_separator(self.config.get_sqs())
-        self.log.info('Env:%s Creating SQS:%s', self.config.get_env(), qname)
+        self.log.info('Prefix:%s Creating SQS:%s', self.config.get_prefix(), qname)
         q = self.client.create_queue(
             QueueName=qname
         )

--- a/scripts/elb.py
+++ b/scripts/elb.py
@@ -9,7 +9,7 @@ import arg_parser
 
 def setup_and_parse_args():
     parser = arg_parser.create_parser(desc="""
-    Setup ELB in the specified environment/region. Environment implies both region and its use case
+    Setup ELB in the specified prefix/region. Prefix implies use case
 
     Example usage:
     python ./elb_create.py --file=<config-file.yaml>        # (region us-east-1, developer environment)

--- a/scripts/sqs.py
+++ b/scripts/sqs.py
@@ -15,7 +15,7 @@ import arg_parser
 
 def setup_and_parse_args():
     parser = arg_parser.create_parser(desc="""
-    Setup AWS SQS in the specified environment/region. Environment implies both region and its use case
+    Setup AWS SQS in the specified prefix/region. prefix implies use case
 
     Example usage:
     python ./sqs_create.py --file=<config-file.yaml>        # (region us-east-1, developer environment)


### PR DESCRIPTION
Support Network load balancers (with TCP listeners)
Upon upgrade, wait for EC2 autoscaling to finish downscaling before updating ECS auto scaling. This ensures that only old instances will be removed.
Support "alternate" listeners, so an ELB can listen on 2 ports, 443 with SSL 80 without, for example